### PR TITLE
本番環境でRails APIにリクエストが送れないbugを解消する（解決） 

### DIFF
--- a/backend/app/controllers/api/v1/sutras_controller.rb
+++ b/backend/app/controllers/api/v1/sutras_controller.rb
@@ -9,10 +9,14 @@ module Api
       end
 
       def show
-        @sutra = Sutra.find(params[:id])
-        render json: @sutra
+        begin
+          sutra = Sutra.find(params[:id])
+          render json: sutra
+        rescue ActiveRecord::RecordNotFound => e
+          render json: { error: e.message }, status: :not_found
+        end
       end
-      
+
       def new; end
 
       def create; end

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -7,11 +7,11 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "*"
+    origins Rails.application.credentials.next_url
 
     resource "*",
             headers: :any,
             methods: [:get, :post, :put, :patch, :delete, :options, :head],
-            credentials: false
+            credentials: true
   end
 end


### PR DESCRIPTION
## Issues

- #179
- #183 

## 原因
Fly.ioのデータベースに初期データが投入できていなかったことが原因だった。

## 解決方法
`flyctl ssh console`コマンドを使用し実行中のアプリのインスタンスに接続する
そこから`bin/rails db:seed RAILS_ENV=production`を実行し初期データを投入することができた
詳細はissue #183 にまとめる