### PR TITLE
パフォーマンスチューニング：アプリのMachinesを常に常時2台稼働する設定に変更する

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -17,7 +17,7 @@ console_command = "/rails/bin/rails console"
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 2
   processes = ["app"]
 
 [[statics]]


### PR DESCRIPTION
## Issue
- #471

### 関連Issue
- #454

## やったこと
`1`から`2`に設定を変更する。
```
# backend/fly.toml

[http_service]
  internal_port = 3000
  force_https = true
  auto_stop_machines = true
  auto_start_machines = true
  min_machines_running = 2
  processes = ["app"]
```

